### PR TITLE
Título das referências em negrito em vez de itálico

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ Arquivo exemplo
 ===============
 
 O arquivo-exemplo.tex localizado no diretório raiz, é um arquivo auto explicativo e deve ser utilizado em sua dissertação, pois nele está contido configurações necessárias não inseridas no template de formatação.
+
+Palavras-chave
+==============
+IPT, LaTeX

--- a/arquivo-exemplo.tex
+++ b/arquivo-exemplo.tex
@@ -53,7 +53,7 @@
 % Pacotes de citações
 % ---
 % \usepackage[brazilian,hyperpageref]{backref}	 % Paginas com as citações na bibl
-\usepackage[alf,abnt-emphasize=bf]{abntex2cite}    % Citações padrão ABNT/IPT
+\usepackage[alf,abnt-emphasize=bf]{abntex2cite}    % Citações padrão ABNT, com títulos em negrito, conforme Guia do Mestrado IPT, 2013
 
 % ---
 % CONFIGURAÇÕES DE PACOTES

--- a/arquivo-exemplo.tex
+++ b/arquivo-exemplo.tex
@@ -53,7 +53,7 @@
 % Pacotes de citações
 % ---
 % \usepackage[brazilian,hyperpageref]{backref}	 % Paginas com as citações na bibl
-\usepackage[alf]{abntex2cite}    % Citações padrão ABNT
+\usepackage[alf,abnt-emphasize=bf]{abntex2cite}    % Citações padrão ABNT/IPT
 
 % ---
 % CONFIGURAÇÕES DE PACOTES


### PR DESCRIPTION
Caro João, em primeiro lugar gostaria de agradecer pelo seu trabalho ao criar esse template. Me salvou (e a muitos outros, creio eu) de horas de tweaking no Latex e ainda, da triste possibilidade de ter de usar o Word para escrever o trabalho.

Fiz duas micro-alterações:
- De acordo com o Guia do Mestrado do IPT divulgado em 2013, os títulos das referências devem estar em negrito. Alterei o parâmetro que mexe nisso;
- Ao buscar "ipt latex" no google, o seu repo não aparece nas primeiras páginas. Mexi no README para ver se melhora;

Mais uma vez, muito obrigado.

Mateus
